### PR TITLE
add sysmacros patch for cramfs 1.1 and squashfs 4.2 for major/minor/makedev

### DIFF
--- a/make/bootstrap.mk
+++ b/make/bootstrap.mk
@@ -101,6 +101,7 @@ $(D)/host_mtd_utils: $(D)/directories $(ARCHIVE)/$(HOST_MTD_UTILS_SOURCE)
 #
 HOST_MKCRAMFS_VER = 1.1
 HOST_MKCRAMFS_SOURCE = cramfs-$(HOST_MKCRAMFS_VER).tar.gz
+HOST_MKCRAMFS_PATCH = cramfs-$(HOST_MKCRAMFS_VER)-sysmacros.patch
 
 $(ARCHIVE)/$(HOST_MKCRAMFS_SOURCE):
 	$(WGET) https://sourceforge.net/projects/cramfs/files/cramfs/$(HOST_MKCRAMFS_VER)/$(HOST_MKCRAMFS_SOURCE)
@@ -110,6 +111,7 @@ $(D)/host_mkcramfs: $(D)/directories $(ARCHIVE)/$(HOST_MKCRAMFS_SOURCE)
 	$(REMOVE)/cramfs-$(HOST_MKCRAMFS_VER)
 	$(UNTAR)/$(HOST_MKCRAMFS_SOURCE)
 	$(CHDIR)/cramfs-$(HOST_MKCRAMFS_VER); \
+		$(call apply_patches,$(HOST_MKCRAMFS_PATCH)); \
 		$(MAKE) all
 		cp $(BUILD_TMP)/cramfs-$(HOST_MKCRAMFS_VER)/mkcramfs $(HOST_DIR)/bin
 		cp $(BUILD_TMP)/cramfs-$(HOST_MKCRAMFS_VER)/cramfsck $(HOST_DIR)/bin
@@ -141,6 +143,7 @@ $(D)/host_mksquashfs3: directories $(ARCHIVE)/$(HOST_MKSQUASHFS3_SOURCE)
 #
 HOST_MKSQUASHFS_VER = 4.2
 HOST_MKSQUASHFS_SOURCE = squashfs$(HOST_MKSQUASHFS_VER).tar.gz
+HOST_MKSQUASHFS_PATCH = squashfs-$(HOST_MKSQUASHFS_VER)-sysmacros.patch
 
 LZMA_VER = 4.65
 LZMA_SOURCE = lzma-$(LZMA_VER).tar.bz2
@@ -158,6 +161,7 @@ $(D)/host_mksquashfs: directories $(ARCHIVE)/$(LZMA_SOURCE) $(ARCHIVE)/$(HOST_MK
 	$(REMOVE)/squashfs$(HOST_MKSQUASHFS_VER)
 	$(UNTAR)/$(HOST_MKSQUASHFS_SOURCE)
 	$(CHDIR)/squashfs$(HOST_MKSQUASHFS_VER); \
+		$(call apply_patches,$(HOST_MKSQUASHFS_PATCH)); \
 		$(MAKE) -C squashfs-tools \
 			LZMA_SUPPORT=1 \
 			LZMA_DIR=$(BUILD_TMP)/lzma-$(LZMA_VER) \

--- a/patches/cramfs-1.1-sysmacros.patch
+++ b/patches/cramfs-1.1-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/mkcramfs.c
++++ b/mkcramfs.c
+@@ -23,6 +23,7 @@
+  */
+ 
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <stdio.h>
+ #include <sys/stat.h>
+ #include <unistd.h>

--- a/patches/squashfs-4.2-sysmacros.patch
+++ b/patches/squashfs-4.2-sysmacros.patch
@@ -1,0 +1,21 @@
+--- a/squashfs-tools/mksquashfs.c
++++ b/squashfs-tools/mksquashfs.c
+@@ -34,6 +34,7 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <fcntl.h>
+ #include <errno.h>
+ #include <dirent.h>
+
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -31,6 +31,7 @@
+ 
+ #include <sys/sysinfo.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ 
+ struct cache *fragment_cache, *data_cache;
+ struct queue *to_reader, *to_deflate, *to_writer, *from_writer; 


### PR DESCRIPTION
does not build without this in my environment since commit https://github.com/Duckbox-Developers/buildsystem-ddt/commit/a566ded06ffcd7d955bf017b4e020f61a4073791