### PR TITLE
Add cpio and bc package

### DIFF
--- a/prepare-for-bs.sh
+++ b/prepare-for-bs.sh
@@ -121,6 +121,8 @@ PACKAGES="\
 	${UBUNTU:+jpegoptim}                                                                                          \
 	${UBUNTU:+libreadline-dev}                                                                                    \
 	${UBUNTU:+autoconf-archive}                                                                                   \
+	${UBUNTU:+cpio}                                                                                               \
+	${UBUNTU:+bc}                                                                                                 \
 ";
 
 if [ "$UBUNTU" == 1 ]; then


### PR DESCRIPTION
Package cpio is used by scripts/unpack-rpm.sh:22
Package bc is used by make/buildenv.mk:167

Both are not part of the official Ubunto docker image.

I'm not sure if other distributions affected also and if this is the right place and way to add it. So please feel free to modify.