### PR TITLE
Fix automatic yes option of apt-get

### DIFF
--- a/prepare-for-bs.sh
+++ b/prepare-for-bs.sh
@@ -23,7 +23,7 @@ if `which lsb_release > /dev/null 2>&1`; then
 		CentOS*) FEDORA=1; INSTALL="yum install -y";;
 		SUSE*)   SUSE=1;   INSTALL="zypper install -y";;
 		Ubuntu*) UBUNTU=1; INSTALL="apt-get -y install";;
-		LinuxM*) UBUNTU=2; INSTALL="apt-get --force-yes install";;
+		LinuxM*) UBUNTU=2; INSTALL="apt-get -y install";;
 		Gentoo)  GENTOO=1; INSTALL="emerge -uN";;
 	esac
 fi
@@ -34,7 +34,7 @@ if [ -z "$FEDORA$GENTOO$SUSE$UBUNTU" ]; then
 	elif [ -f /etc/fedora-release ]; then FEDORA=1; INSTALL="yum install -y"; 
 	elif [ -f /etc/centos-release ]; then FEDORA=1; INSTALL="yum install -y"; 
 	elif [ -f /etc/SuSE-release ];   then SUSE=1;   INSTALL="zypper install -n";
-	elif [ -f /etc/debian_version ]; then UBUNTU=1; INSTALL="apt-get --force-yes install";
+	elif [ -f /etc/debian_version ]; then UBUNTU=1; INSTALL="apt-get -y install";
 	elif [ -f /etc/gentoo-release ]; then GENTOO=1; INSTALL="emerge -uN"
 	fi
 fi


### PR DESCRIPTION
I assume `-y` is the intended option for `apt-get`, at least it is the equivalent to `-y` of `yum`. Additionally, it is inconsistent at the moment: for distribution UBUNTU=1, `apt-get -y` is already used when it is detected in the first attempt (line 25), but for UBUNTU=1 detected in the second attempt, `apt-get --force-yes` is used (line 37).

The man page says:

> -y, --yes, --assume-yes
    Automatic yes to prompts. Assume "yes" as answer to all prompts and run non-interactively. If an undesirable situation, such as changing a held package or removing an essential package, occurs then apt-get will abort.

>--force-yes
    Force yes. This is a dangerous option that will cause apt-get to continue without prompting if it is doing something potentially harmful. It should not be used except in very special situations. Using --force-yes can potentially destroy your system! 