### PR TITLE
New source and version of libpopt

### DIFF
--- a/make/system-libs.mk
+++ b/make/system-libs.mk
@@ -1634,11 +1634,11 @@ endif
 #
 # libpopt
 #
-LIBPOPT_VER = 1.16
+LIBPOPT_VER = 1.19
 LIBPOPT_SOURCE = popt-$(LIBPOPT_VER).tar.gz
 
 $(ARCHIVE)/$(LIBPOPT_SOURCE):
-	$(DOWNLOAD) ftp://anduin.linuxfromscratch.org/BLFS/popt/$(LIBPOPT_SOURCE)
+	$(DOWNLOAD) ftp://ftp.rpm.org/pub/rpm/popt/releases/popt-1.x/$(LIBPOPT_SOURCE)
 
 $(D)/libpopt: $(D)/bootstrap $(ARCHIVE)/$(LIBPOPT_SOURCE)
 	$(START_BUILD)


### PR DESCRIPTION
libpopt 1.16 is no longer available from ftp://anduin.linuxfromscratch.org/BLFS/popt, although it is still linked from https://www.linuxfromscratch.org/blfs/view/basic/popt.html.

So I switched to libpopt 1.19 with sources linked at https://www.linuxfromscratch.org/blfs/view/stable/general/popt.html.